### PR TITLE
构建docker镜像时手动打tag，方便用户选择版本

### DIFF
--- a/.github/workflows/build_image_bhp.yml
+++ b/.github/workflows/build_image_bhp.yml
@@ -1,6 +1,11 @@
 name: "BiliHelper-personal Docker Image Buildx Stable Github"
 on:
   workflow_dispatch:
+    inputs:
+      docker_image_tag:
+        description: 'docker镜像tag:(多个tag用英文逗号分隔.[如:latest,2.0.0.1])'
+        required: true
+        default: 'latest'
 
 jobs:
   build:
@@ -17,6 +22,6 @@ jobs:
           dockerFile: docker/Dockerfile
           platform: linux/amd64,linux/arm64,linux/arm/v7
           # platform: linux/amd64,linux/arm64,linux/arm/v7,linux/arm/v8
-          tag: latest
+          tag: ${{ github.event.inputs.docker_image_tag }}
           dockerUser: ${{ secrets.DOCKER_USERNAME }}
           dockerPassword: ${{ secrets.DOCKER_PASSWORD }}


### PR DESCRIPTION
注意：理论上可用，并未实际测试（主要是懒得再去仓库设置环境变量）

另外看了下这个是默认构建 master 分支的，如果要构建其他分支的话可以改
```
      - name: Checkout master
        uses: actions/checkout@master
```
部分，将 @master 改成其他分支名。也可以设置成像上面那样手动设置变量