### PR TITLE
disables the warning about running commands as root/super use

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -21,7 +21,8 @@ ENV USER_NAME='' \
     Font_color_suffix="\\033[0m" \
     Info="${Green}[信息]${Font}" \
     OK="${Green}[OK]${Font}" \
-    Error="${Red}[错误]${Font}"
+    Error="${Red}[错误]${Font}" \
+    COMPOSER_ALLOW_SUPERUSER=1
 
 WORKDIR /app
 


### PR DESCRIPTION
disables the warning about running commands as root/super use. see https://getcomposer.org/doc/03-cli.md#COMPOSER_ALLOW_SUPERUSER